### PR TITLE
Add directive `manifest-src` to Content-Security-Policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ to the require section of your composer.json.
             'form-action' => "'self'",
             'frame-src' => "'self'",
             'child-src' => "'self'",
-            'worker-src' => "'self'"
+            'worker-src' => "'self'",
+            'manifest-src' => "'self'",
         ],
         'featurePolicyDirectives' => [
             'accelerometer' => "'self'",

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -144,7 +144,8 @@ class Headers extends Component implements BootstrapInterface
         'form-action' => "'self'",
         'frame-src' => "'self'",
         'child-src' => "'self'",
-        'worker-src' => "'self'"
+        'worker-src' => "'self'",
+        'manifest-src' => "'self'",
     ];
 
     /**

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -22,13 +22,13 @@ class HeaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        
+
         // run web application
         $this->mockApplication(require(__DIR__ . '/config/config.php'), 'yii\web\Application');
-        
+
         // trigger event
         Yii::$app->trigger(Application::EVENT_BEFORE_REQUEST);
-        
+
         // init extension
         $this->headers = new Headers();
     }
@@ -47,20 +47,20 @@ class HeaderTest extends TestCase
             ['x-xss-protection', '1; mode=block;']
         ];
     }
-    
+
     /**
      * @dataProvider defaultHeaders
      */
     public function testHeaders($a, $b)
     {
         $defaultHeaders = Yii::$app->response->getHeaders();
-        
+
         $this->assertNotEmpty($defaultHeaders);
         $this->assertCount(8, $defaultHeaders);
         $this->assertArrayHasKey($a, $defaultHeaders);
         $this->assertContains($b, $defaultHeaders[$a]);
     }
-    
+
     /**
      * Test report uri header
      */
@@ -166,6 +166,7 @@ class HeaderTest extends TestCase
         $this->assertContains('default-src', $csp);
         $this->assertContains('script-src', $csp);
         $this->assertContains('worker-src', $csp);
+        $this->assertContains('manifest-src', $csp);
         $this->assertNotContains('require-sri-for', $csp);
         $this->assertContains('block-all-mixed-content', $csp);
         $this->assertContains('upgrade-insecure-requests', $csp);
@@ -217,6 +218,15 @@ class HeaderTest extends TestCase
 
         $this->assertNotEmpty($csp);
         $this->assertNotContains('X-Content-Type-Options', $csp);
+    }
+
+    public function testBuildCspArrayWithOverwriteManifestSrc()
+    {
+        $domain = 'https://example.com/';
+        $this->headers->cspDirectives = ['manifest-src' => $domain];
+        $csp = $this->invokeMethod($this->headers, 'buildCspArray');
+        $this->assertArrayHasKey('manifest-src', $csp);
+        $this->assertEquals($domain, $csp['manifest-src']);
     }
 
     /**


### PR DESCRIPTION
Hello,

Currently we can't set value for directive `manifest-src`.
In Chrome browser we get error as below, if we add manifest file (https://developer.mozilla.org/en-US/docs/Web/Manifest):
Refused to load manifest from '<DOMAIN>' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'manifest-src' was not explicitly set, so 'default-src' is used as a fallback.

This PR allow us to set `manifest-src` directive.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src